### PR TITLE
fix(customer): 顧客削除時に受注データの存在チェックを追加

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -105,5 +105,8 @@ async def create_customer(name: str = Form(...), name_kana: str = Form(None), ad
     return RedirectResponse(url="/master/customers", status_code=303)
 @app.post("/master/customers/{customer_id}/delete")
 async def delete_customer_endpoint(customer_id: int, db: Session = Depends(get_db)):
-    MasterService.delete_customer(db, customer_id)
-    return RedirectResponse(url="/master/customers", status_code=303)
+    try:
+        MasterService.delete_customer(db, customer_id)
+        return RedirectResponse(url="/master/customers", status_code=303)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/app/services/services.py
+++ b/app/services/services.py
@@ -48,6 +48,11 @@ class MasterService:
     def delete_customer(db: Session, customer_id: int):
         customer = db.query(Customer).filter(Customer.id == customer_id).first()
         if customer:
+            # 受注データの存在チェック
+            order_count = db.query(Order).filter(Order.customer_id == customer_id).count()
+            if order_count > 0:
+                raise Exception(f"この顧客には{order_count}件の受注データが紐づいているため削除できません。")
+            
             db.delete(customer)
             db.commit()
         return customer


### PR DESCRIPTION
## 変更の概要
受注データが紐づいている顧客を削除しようとした際に、データベースの外部キー制約により Internal Error が発生していた問題を修正しました。

## 問題点
- 受注データがある顧客（山田花子）を削除しようとすると Internal Error
- 受注データがない顧客（山田太郎）は正常に削除可能

## 修正内容
### 1. サービス層（`app/services/services.py`）
- `delete_customer`メソッドに受注データの存在チェックを追加
- 受注データが存在する場合は、件数を含む日本語のエラーメッセージを投げる

### 2. エンドポイント層（`app/main.py`）
- 削除エンドポイントに try-except によるエラーハンドリングを追加
- HTTPException (400 Bad Request) として適切に処理

## テスト内容
動作確認を実施しました：
1. **山田花子（受注1件）の削除**: 「この顧客には1件の受注データが紐づいているため削除できません。」というエラーメッセージが表示される ✅
2. **山田太郎（受注0件）の削除**: 正常に削除される ✅

## 影響範囲
- 既存の受注データの整合性を保護
- データベース構造への変更なし

## 関連Issue
Closes #1