### PR TITLE
feat(customer): 顧客削除のエラーメッセージをページ内表示に変更

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -107,6 +107,6 @@ async def create_customer(name: str = Form(...), name_kana: str = Form(None), ad
 async def delete_customer_endpoint(customer_id: int, db: Session = Depends(get_db)):
     try:
         MasterService.delete_customer(db, customer_id)
-        return RedirectResponse(url="/master/customers", status_code=303)
+        return {"success": True, "message": "顧客を正常に削除しました。"}
     except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        return {"success": False, "message": str(e)}

--- a/app/templates/customers.html
+++ b/app/templates/customers.html
@@ -5,6 +5,14 @@
 {% block page_subtitle %}取引先情報の登録と、連絡先データベースの管理を行います。{% endblock %}
 
 {% block content %}
+<!-- メッセージ表示エリア -->
+<div id="messageArea" class="hidden mb-6 p-6 rounded-[2rem] border-2 transition-all">
+    <div class="flex items-center space-x-3">
+        <div id="messageIcon" class="w-10 h-10 rounded-xl flex items-center justify-center"></div>
+        <p id="messageText" class="font-bold text-sm"></p>
+    </div>
+</div>
+
 <div class="flex flex-col xl:flex-row gap-10">
     <!-- Left: Customer Registration Form -->
     <div class="xl:w-80 flex flex-col gap-6">
@@ -99,13 +107,10 @@
                                 <span class="text-xs font-bold text-indigo-500 font-mono">{{ customer.contact }}</span>
                             </td>
                             <td class="px-8 py-6 text-right">
-                                <form method="post" action="/master/customers/{{ customer.id }}/delete" 
-                                      onsubmit="return confirm('この顧客「' + '{{ customer.name }}' + '」を削除してもよろしいですか？');" 
-                                      style="display:inline;">
-                                    <button type="submit" class="text-red-400 hover:text-red-600 transition-colors font-bold text-sm">
-                                        削除
-                                    </button>
-                                </form>
+                                <button onclick="deleteCustomer({{ customer.id }}, '{{ customer.name }}')"
+                                        class="text-red-400 hover:text-red-600 transition-colors font-bold text-sm">
+                                    削除
+                                </button>
                             </td>
                         </tr>
                         {% endfor %}
@@ -120,4 +125,69 @@
         </div>
     </div>
 </div>
+
+<script>
+function showMessage(message, isSuccess) {
+    const messageArea = document.getElementById('messageArea');
+    const messageIcon = document.getElementById('messageIcon');
+    const messageText = document.getElementById('messageText');
+    
+    if (isSuccess) {
+        messageArea.className = 'mb-6 p-6 rounded-[2rem] border-2 border-emerald-500 bg-emerald-50 transition-all';
+        messageIcon.className = 'w-10 h-10 rounded-xl bg-emerald-500 flex items-center justify-center text-white';
+        messageIcon.innerHTML = `
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+            </svg>
+        `;
+        messageText.className = 'font-bold text-sm text-emerald-800';
+    } else {
+        messageArea.className = 'mb-6 p-6 rounded-[2rem] border-2 border-rose-500 bg-rose-50 transition-all';
+        messageIcon.className = 'w-10 h-10 rounded-xl bg-rose-500 flex items-center justify-center text-white';
+        messageIcon.innerHTML = `
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+        `;
+        messageText.className = 'font-bold text-sm text-rose-800';
+    }
+    
+    messageText.textContent = message;
+    messageArea.classList.remove('hidden');
+    
+    // 5秒後に自動的に非表示
+    setTimeout(() => {
+        messageArea.classList.add('hidden');
+    }, 5000);
+}
+
+async function deleteCustomer(customerId, customerName) {
+    if (!confirm(`この顧客「${customerName}」を削除してもよろしいですか？`)) {
+        return;
+    }
+    
+    try {
+        const response = await fetch(`/master/customers/${customerId}/delete`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            }
+        });
+        
+        const data = await response.json();
+        
+        if (data.success) {
+            showMessage(data.message, true);
+            // ページをリロードして顧客リストを更新
+            setTimeout(() => {
+                window.location.reload();
+            }, 1000);
+        } else {
+            showMessage(data.message, false);
+        }
+    } catch (error) {
+        showMessage('削除処理中にエラーが発生しました。', false);
+    }
+}
+</script>
 {% endblock %}


### PR DESCRIPTION
## 変更の概要
顧客削除時のエラー/成功メッセージを、画面遷移なしでページ内に表示する機能を実装しました。

## 問題点（Before）
- 削除エラー時に別ページに遷移してエラーメッセージが表示される
- ユーザーがコンテキストを失い、UXが低下する

## 改善内容（After）
- 顧客マスター画面内にメッセージ表示エリアを追加
- AJAX ベースの削除処理で画面遷移を排除
- 成功/エラーメッセージをGlassmorphismスタイルで表示

## 修正内容

### 1. フロントエンド（`app/templates/customers.html`）
- **メッセージ表示エリア**: ページ上部に追加（初期状態は非表示）
  - 成功メッセージ: エメラルドグリーンのカード
  - エラーメッセージ: ローズピンクのカード
- **削除処理のAJAX化**: 
  - `deleteCustomer()` 関数を実装
  - fetch API で `/master/customers/{id}/delete` にPOST
  - レスポンスに基づいてメッセージを表示
- **自動リロード**: 削除成功時は1秒後にページをリロードして顧客リストを更新

### 2. バックエンド（`app/main.py`）
- **削除エンドポイント変更**: RedirectResponse から JSON レスポンスに変更
- **レスポンス形式**: `{"success": true/false, "message": "..."}`

## 動作確認

APIレベルでのテスト結果:

### ケース1: 受注データありの顧客（山田花子）
```bash
curl -X POST http://localhost:8000/master/customers/4/delete
```
**結果**: 
```json
{
  "success": false,
  "message": "この顧客には1件の受注データが紐づいているため削除できません。"
}
```
✅ エラーメッセージが正しく返される

### ケース2: 受注データなしの顧客（山田太郎）
```bash
curl -X POST http://localhost:8000/master/customers/5/delete
```
**結果**: 
```json
{
  "success": true,
  "message": "顧客を正常に削除しました。"
}
```
✅ 削除成功メッセージが返され、データベースから削除される

## UI/UXデザイン
- **デザインシステム遵守**: Glassmorphismスタイル（Luminous Clarity）に準拠
- **カラーパレット**: 
  - 成功: Emerald (`#10b981`)
  - エラー: Rose (`#f43f5e`)
- **振る舞い**: 
  - メッセージは5秒後に自動的に非表示
  - 削除成功時は1秒後に自動リロード
  - すべてのメッセージは日本語

## 影響範囲
- ✅ 既存の顧客削除バリデーション（受注データチェック）は維持
- ✅ データベース構造への変更なし
- ✅ 他の画面への影響なし

## 関連Issue
Closes #5