### PR TITLE
fix(security): resolve XSS and CSRF vulnerabilities in customer deletion

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Depends, Request, Form, HTTPException
+from fastapi import FastAPI, Depends, Request, Form, HTTPException, Header
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -104,7 +104,14 @@ async def create_customer(name: str = Form(...), name_kana: str = Form(None), ad
     MasterService.create_customer(db, name, address, contact, name_kana)
     return RedirectResponse(url="/master/customers", status_code=303)
 @app.post("/master/customers/{customer_id}/delete")
-async def delete_customer_endpoint(customer_id: int, db: Session = Depends(get_db)):
+async def delete_customer_endpoint(
+    customer_id: int, 
+    x_requested_with: str = Header(None),
+    db: Session = Depends(get_db)
+):
+    if x_requested_with != "XMLHttpRequest":
+        return {"success": False, "message": "不正なリクエストです(CSRF保護)。"}
+        
     try:
         MasterService.delete_customer(db, customer_id)
         return {"success": True, "message": "顧客を正常に削除しました。"}

--- a/app/templates/customers.html
+++ b/app/templates/customers.html
@@ -107,7 +107,9 @@
                                 <span class="text-xs font-bold text-indigo-500 font-mono">{{ customer.contact }}</span>
                             </td>
                             <td class="px-8 py-6 text-right">
-                                <button onclick="deleteCustomer({{ customer.id }}, '{{ customer.name }}')"
+                                <button data-customer-id="{{ customer.id }}"
+                                        data-customer-name="{{ customer.name }}"
+                                        onclick="deleteCustomer(this)"
                                         class="text-red-400 hover:text-red-600 transition-colors font-bold text-sm">
                                     削除
                                 </button>
@@ -161,7 +163,10 @@ function showMessage(message, isSuccess) {
     }, 5000);
 }
 
-async function deleteCustomer(customerId, customerName) {
+async function deleteCustomer(buttonElement) {
+    const customerId = buttonElement.getAttribute('data-customer-id');
+    const customerName = buttonElement.getAttribute('data-customer-name');
+    
     if (!confirm(`この顧客「${customerName}」を削除してもよろしいですか？`)) {
         return;
     }
@@ -170,9 +175,13 @@ async function deleteCustomer(customerId, customerName) {
         const response = await fetch(`/master/customers/${customerId}/delete`, {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest'
             }
         });
+        
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
         
         const data = await response.json();
         


### PR DESCRIPTION
## 変更の概要
旧PR #6 にて `gemini-code-review` から指摘された以下の高重大度(High Severity)の脆弱性を解消するためのセキュリティパッチです。元のPRがすでにクローズされていたため、改めて修正PRとして作成しました。

1. **Stored XSS 対策:**
   フロントエンドの `customers.html` にてJS内に直接値を展開する危険な実装を廃止し、`data-*` 属性を利用するセキュアな設計へ変更しました。
2. **CSRF 保護の追加:**
   削除エンドポイント (`/master/customers/{id}/delete`) に対し、Ajaxリクエストであることを証明する `X-Requested-With: XMLHttpRequest` ヘッダーの検証を必須としました。
3. **不要なヘッダーの削除とエラーハンドリング強化:**
   フェッチAPIのエラー捕捉処理を追加し、不要な `Content-Type` ヘッダーを取り除きました。